### PR TITLE
Use HTML links in interpretation notification messages

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/interpretation/impl/DefaultInterpretationService.java
@@ -32,6 +32,7 @@ import org.hisp.dhis.chart.Chart;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.SubscribableObject;
+import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.interpretation.Interpretation;
 import org.hisp.dhis.interpretation.InterpretationComment;
 import org.hisp.dhis.interpretation.InterpretationService;
@@ -287,7 +288,7 @@ public class DefaultInterpretationService
             String.format( "%s %s", i18n.getString( "go_to" ), getInterpretationLink( interpretation ) )
         ) );
         
-        return messageService.createSystemMessage( users, subject, fullBody ).build();
+        return messageService.createSystemMessage( users, subject, TextUtils.htmlLinks( fullBody ) ).build();
     }
 
     private void notifySubscribers( Interpretation interpretation, InterpretationComment comment, NotificationType notificationType )
@@ -334,7 +335,7 @@ public class DefaultInterpretationService
         StringBuilder subjectContent = new StringBuilder( user.getDisplayName() ).append( " " )
             .append( i18n.getString( "mentioned_you_in_dhis2" ) );
         messageService.sendMessage( messageService
-            .createPrivateMessage( users, subjectContent.toString(), messageContent.toString(), "Meta" ).build() );
+            .createPrivateMessage( users, subjectContent.toString(), TextUtils.htmlLinks( messageContent.toString() ), "Meta" ).build() );
     }
 
     private String getInterpretationLink( Interpretation interpretation ) {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #57 
* **Next task:** when approved, open upstream PRs for 2.30, 2.31 and master.

### :memo: Implementation

- Use `TextUtils.htmlLinks` in messages: mention and creation/update of interpretation/comment.


### :art: Screenshots

![screenshot from 2018-12-03 11-27-13](https://user-images.githubusercontent.com/24643/49368926-5e54cd80-f6f0-11e8-9f24-5f5bb92cce5b.png)
![screenshot from 2018-12-03 11-27-21](https://user-images.githubusercontent.com/24643/49368927-5e54cd80-f6f0-11e8-90f0-b622e9b8206d.png)

