### PR TITLE
[OCG] [fix] On tracker TEIs sync, copy only teis updated [DHIS2-15223]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -615,6 +615,13 @@ public class HibernateTrackedEntityInstanceStore
             }
         }
 
+        if ( params.isSynchronizationQuery() )
+        {
+            trackedEntity
+                .append( whereAnd.whereAnd() )
+                .append( " TEI.lastupdated >= TEI.lastSynchronized " );
+        }
+
         if ( !params.isIncludeDeleted() )
         {
             trackedEntity


### PR DESCRIPTION
On 2.37.8.1, all TEIs are synced on the job sync, even if they were already synced before. This worked for 2.33.5, so let's compare:

https://github.com/dhis2/dhis2-core/blob/2.37.8.1/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java#L603

https://github.com/dhis2/dhis2-core/blob/2.33.5/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java#L264

The problems is that the condition "tei.lastUpdated > tei.lastSynchronized" when params.isSynchronizationQuery()"  was removed. Checking git history, this logic was changed here (first affected version: 2.37.3):

https://github.com/dhis2/dhis2-core/commit/ed1a022b384f4cd3f8dd5051ef9af68c30177869#diff-f960125887353fe285946328173a4e612632e40c0bca283e9d30c824348764dbL383

And the logic was reinstated here (first version fixed: 2.38.4, not backported to 2.37):

https://github.com/dhis2/dhis2-core/commit/946c066c0722c2e40e4e69af090a42325d52b0a0#diff-f960125887353fe285946328173a4e612632e40c0bca283e9d30c824348764dbR663

Associated JIRA issue: https://dhis2.atlassian.net/browse/DHIS2-15223