### PR TITLE
[SPIP] fix: check fileResource null reference

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/postprocess/EventFileResourcePostProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/postprocess/EventFileResourcePostProcessor.java
@@ -51,7 +51,8 @@ public class EventFileResourcePostProcessor implements Processor {
       if (dataElement.isFileType()) {
         FileResource fileResource = fileResourceService.getFileResource(dataValue.getValue());
 
-        if (!fileResource.isAssigned() || fileResource.getFileResourceOwner() == null) {
+        if (fileResource != null
+            && (!fileResource.isAssigned() || fileResource.getFileResourceOwner() == null)) {
           fileResource.setAssigned(true);
           fileResource.setFileResourceOwner(event.getEvent());
           fileResourceService.updateFileResource(fileResource);


### PR DESCRIPTION
[86955xy5e]

When trying to delete a file (dataElement of type FILE_RESOURCE), the event PUT fails with a NullPointerException. This PR fixes the problem.