### PR TITLE
[OCG] fix: make nextYearStartDate use the offset of the weekly type [2.37]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateUnitPeriodTypeParser.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateUnitPeriodTypeParser.java
@@ -133,7 +133,7 @@ public class DateUnitPeriodTypeParser implements PeriodTypeParser, Serializable
             WeeklyAbstractPeriodType periodType = (WeeklyAbstractPeriodType) PeriodType
                 .getByNameIgnoreCase( dateUnitType.getName() );
 
-            if ( periodType == null || week < 1 || week > calendar.weeksInYear( year ) )
+            if ( periodType == null || week < 1 || week > calendar.weeksInYear( year ) + 1 )
             {
                 return null;
             }

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.period.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.period.js
@@ -758,7 +758,7 @@ $.extend( dhis2.period.WeeklyWednesdayGenerator.prototype, {
     var periods = [];
 
     var startDate = dhis2.period.getStartDateOfYear( this.calendar, year, 3 );
-    var nextYearStartDate = Date.parse( dhis2.period.getStartDateOfYear( this.calendar, year + 1, 1 ) );
+    var nextYearStartDate = Date.parse( dhis2.period.getStartDateOfYear( this.calendar, year + 1, 3 ) );
 
     // no reliable way to figure out number of weeks in a year (can differ in different calendars)
     // goes up to 200, but break when week is back to 1
@@ -815,7 +815,7 @@ $.extend( dhis2.period.WeeklyThursdayGenerator.prototype, {
     var periods = [];
 
     var startDate = dhis2.period.getStartDateOfYear( this.calendar, year, 4 );
-    var nextYearStartDate = Date.parse( dhis2.period.getStartDateOfYear( this.calendar, year + 1, 1 ) );
+    var nextYearStartDate = Date.parse( dhis2.period.getStartDateOfYear( this.calendar, year + 1, 4 ) );
 
     // no reliable way to figure out number of weeks in a year (can differ in different calendars)
     // goes up to 200, but break when week is back to 1
@@ -874,7 +874,7 @@ $.extend( dhis2.period.WeeklySaturdayGenerator.prototype, {
     var periods = [];
 
     var startDate = dhis2.period.getStartDateOfYear( this.calendar, year, 6 );
-    var nextYearStartDate = Date.parse( dhis2.period.getStartDateOfYear( this.calendar, year + 1, 1 ) );
+    var nextYearStartDate = Date.parse( dhis2.period.getStartDateOfYear( this.calendar, year + 1, 6 ) );
 
     // no reliable way to figure out number of weeks in a year (can differ in different calendars)
     // goes up to 200, but break when week is back to 1
@@ -933,7 +933,7 @@ $.extend( dhis2.period.WeeklySundayGenerator.prototype, {
     var periods = [];
 
     var startDate = dhis2.period.getStartDateOfYear( this.calendar, year, 7 );
-    var nextYearStartDate = Date.parse( dhis2.period.getStartDateOfYear( this.calendar, year + 1, 1 ) );
+    var nextYearStartDate = Date.parse( dhis2.period.getStartDateOfYear( this.calendar, year + 1, 7 ) );
 
     // no reliable way to figure out number of weeks in a year (can differ in different calendars)
     // goes up to 200, but break when week is back to 1


### PR DESCRIPTION
* Required by https://app.clickup.com/t/8697cvhaj

https://community.dhis2.org/t/quick-way-to-add-missing-iso-weeks-going-back-to-2011/2147/9

https://dhis2.atlassian.net/browse/DHIS2-18762 

- Fix: When calculating nextYearStartDate, the caller passes always 1, but that's only correct for Weekly-Monday. The offset for all the other weekly types were wrong (always 1), all fixed.