### PR TITLE
[SPIP] Support SMS with spaces

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SimplisticHttpGetGateWay.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SimplisticHttpGetGateWay.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.sms.config;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import java.net.URI;
 import java.util.Base64;
 import java.util.Collections;
@@ -152,7 +153,11 @@ public class SimplisticHttpGetGateWay extends SmsGateway {
       }
     }
 
-    valueStore.put(KEY_TEXT, config.isSendUrlParameters() ? SmsUtils.encode(text) : text);
+    valueStore.put(
+        KEY_TEXT,
+        config.isSendUrlParameters()
+            ? SmsUtils.encode(text)
+            : new String(JsonStringEncoder.getInstance().quoteAsString(text)));
     valueStore.put(KEY_RECIPIENT, StringUtils.join(recipients, ","));
 
     return valueStore;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SimplisticHttpGetGateWay.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SimplisticHttpGetGateWay.java
@@ -152,7 +152,7 @@ public class SimplisticHttpGetGateWay extends SmsGateway {
       }
     }
 
-    valueStore.put(KEY_TEXT, SmsUtils.encode(text));
+    valueStore.put(KEY_TEXT, config.isSendUrlParameters() ? SmsUtils.encode(text) : text);
     valueStore.put(KEY_RECIPIENT, StringUtils.join(recipients, ","));
 
     return valueStore;


### PR DESCRIPTION
Required by https://app.clickup.com/t/8696nmumu

Motivation: When a SMS message body is "word1 word", the final request is "word1+word". This URL encoding makes sense when the body is part of a query string, but that's not our use case (nor the typical use case), when we POST the body as JSON, so no encoding is required. We add a conditional so we do not break URL mode.