### PR TITLE
[WIDP] fix: Prevent duplicates after full analytics 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableUpdateParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableUpdateParams.java
@@ -81,6 +81,12 @@ public class AnalyticsTableUpdateParams {
   /** Current date, only used for testing */
   private Date today;
 
+  /**
+   * HACK: startDate for checking if there were recent changes. If set, getLatestAnalyticsTable uses
+   * this value instead of the lastSuccessfulUpdate to determine if it hasUpdatedData
+   */
+  private Date forcedStartDate;
+
   private final Map<String, Object> extraParameters = new HashMap<>();
 
   public void addExtraParam(String prefix, String key, Object value) {
@@ -171,8 +177,8 @@ public class AnalyticsTableUpdateParams {
     params.jobId = this.jobId;
     params.startTime = this.startTime;
     params.lastSuccessfulUpdate = this.lastSuccessfulUpdate;
-
-    return this;
+    params.forcedStartDate = this.forcedStartDate;
+    return params;
   }
 
   public static Builder newBuilder() {
@@ -232,6 +238,11 @@ public class AnalyticsTableUpdateParams {
 
     public Builder withLastSuccessfulUpdate(Date lastSuccessfulUpdate) {
       this.params.lastSuccessfulUpdate = lastSuccessfulUpdate;
+      return this;
+    }
+
+    public Builder withForcedStartDate(Date forcedStartDate) {
+      this.params.forcedStartDate = forcedStartDate;
       return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -383,7 +383,11 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
     Date lastLatestPartitionUpdate =
         systemSettingManager.getDateSetting(
             SettingKey.LAST_SUCCESSFUL_LATEST_ANALYTICS_PARTITION_UPDATE);
-    Date lastAnyTableUpdate = DateUtils.getLatest(lastLatestPartitionUpdate, lastFullTableUpdate);
+
+    Date lastAnyTableUpdate =
+        (params.getForcedStartDate() != null)
+            ? params.getForcedStartDate()
+            : DateUtils.getLatest(lastLatestPartitionUpdate, lastFullTableUpdate);
 
     Assert.notNull(
         lastFullTableUpdate,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 import static org.hisp.dhis.util.DateUtils.toLongDate;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -170,6 +171,22 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
       progress.startingStage("Removing updated and deleted data " + tableType, SKIP_STAGE);
       progress.runStage(() -> tableManager.removeUpdatedData(tables));
       clock.logTime("Removed updated and deleted data");
+    } else { // is full update
+      // Delete contents from the latest partition since the last full execution.
+      // This prevents duplication of values already computed in other partitions as part of the
+      // current full update
+      progress.startingStage(
+          "Removing updated and deleted data [full-fix] " + tableType, SKIP_STAGE);
+      AnalyticsTableUpdateParams paramsLatestPartition =
+          AnalyticsTableUpdateParams.newBuilder(params)
+              .withLatestPartition()
+              .withForcedStartDate(
+                  systemSettingManager.getSystemSetting(
+                      SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_UPDATE, Date.class))
+              .build();
+      List<AnalyticsTable> latestPartition = tableManager.getAnalyticsTables(paramsLatestPartition);
+      progress.runStage(() -> tableManager.removeUpdatedData(latestPartition));
+      clock.logTime("Removed updated and deleted data [full-fix]");
     }
 
     swapTables(params, tables, progress);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -418,7 +418,11 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
     Date lastLatestPartitionUpdate =
         systemSettingManager.getDateSetting(
             SettingKey.LAST_SUCCESSFUL_LATEST_ANALYTICS_PARTITION_UPDATE);
-    Date lastAnyTableUpdate = DateUtils.getLatest(lastLatestPartitionUpdate, lastFullTableUpdate);
+
+    Date lastAnyTableUpdate =
+        (params.getForcedStartDate() != null)
+            ? params.getForcedStartDate()
+            : DateUtils.getLatest(lastLatestPartitionUpdate, lastFullTableUpdate);
 
     Assert.notNull(
         lastFullTableUpdate,


### PR DESCRIPTION
Required by: https://app.clickup.com/t/8698a46rw

After full analytics run, aggregated data was duplicated because it was still in latest partition (i.e. `analytics_0`) while it was also added to the corresponding partition table (i.e. `analytics_2025`). 

This is a workaround to force the removal of data from latest partition after full analytics for each type of table.