### PR TITLE
[SPIP] fix: DataEntry app not loading due to sessionStorage limits

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -96,6 +96,9 @@ dhis2.de.currentCompletedByUser = null;
 // Instance of the StorageManager
 dhis2.de.storageManager = new StorageManager();
 
+// Object to store metaData and dataSetAssociations
+dhis2.de.metaDataStorage = {};
+
 // Indicates whether current form is multi org unit
 dhis2.de.multiOrganisationUnit = false;
 
@@ -332,11 +335,11 @@ dhis2.de.loadMetaData = function()
     	dataType: 'json',
     	success: function( json )
 	    {
-	        sessionStorage[dhis2.de.cst.metaData] = JSON.stringify( json.metaData );
+	        dhis2.de.metaDataStorage[dhis2.de.cst.metaData] = json.metaData;
 	    },
 	    complete: function()
 	    {
-	        var metaData = JSON.parse( sessionStorage[dhis2.de.cst.metaData] );
+	        var metaData = dhis2.de.metaDataStorage[dhis2.de.cst.metaData];
 	        dhis2.de.emptyOrganisationUnits = metaData.emptyOrganisationUnits;
 	        dhis2.de.significantZeros = metaData.significantZeros;
 	        dhis2.de.dataElements = metaData.dataElements;
@@ -363,11 +366,11 @@ dhis2.de.loadDataSetAssociations = function()
     	dataType: 'json',
     	success: function( json )
 	    {
-	        sessionStorage[dhis2.de.cst.dataSetAssociations] = JSON.stringify( json.dataSetAssociations );
+	        dhis2.de.metaDataStorage[dhis2.de.cst.dataSetAssociations] = json.dataSetAssociations;
 	    },
 	    complete: function()
 	    {
-	        var metaData = JSON.parse( sessionStorage[dhis2.de.cst.dataSetAssociations] );
+	        var metaData = dhis2.de.metaDataStorage[dhis2.de.cst.dataSetAssociations];
 	        dhis2.de.dataSetAssociationSets = metaData.dataSetAssociationSets;
 	        dhis2.de.organisationUnitAssociationSetMap = metaData.organisationUnitAssociationSetMap;	        
 	        def.resolve();


### PR DESCRIPTION
**Related Issue**: https://app.clickup.com/t/8698nqxmt

When loading the DataEntry app as a user with access to a large set of metadata, the app won't load if the size of the metadata response exceeds the 5mb sessionStorage quota allowed by browsers.

fix: use variables instead of sessionStorage to avoid the `QuotaExceededError`. 

At first tried using indexedDb as a replacement, but since I couldn't find references to these sessionStorage keys anywhere else, a simpler approach is to use common in-memory variables.