### PR TITLE
[WIDP] fix: dataentry app - optionSets error handling

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -3585,13 +3585,15 @@ dhis2.de.loadOptionSets = function()
                             url: '../api/optionSets/' + item.uid + '.json?fields=' + encodedFields,
                             type: 'GET',
                             cache: false
-                        } ).done( function ( data ) {
+                        } ).then( function ( data ) {
                             console.log( 'Successfully stored optionSet: ' + item.uid );
 
                             var obj = {};
                             obj.id = item.uid;
                             obj.optionSet = data;
                             DAO.store.set( 'optionSets', obj );
+                        }, function (error) {
+                            console.warn( 'Failed to load optionSet: ' + item.uid, error);
                         } );
                     } );
 


### PR DESCRIPTION
**Required by**: https://app.clickup.com/t/8698ye9ce

The dataentry app when first loads, retrieves all existing optionSets when calling the `getMetaData.action` endpoint. After that, each optionSet is individually get. But for some users, these GET requests fail with a 404 error, possibly due to permissions. This was unhandled, causing all the optionSets included in the form to not render properly.

This is a simple patch that handles this error by logging a warning to the console and avoiding the error to propagate rendering the form unusable. 