### PR TITLE
[OCG] [workaround] ensure the security context has no authentication on metadata sync

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
@@ -53,6 +53,8 @@ import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.retry.support.RetryTemplate;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -152,6 +154,11 @@ public class MetadataSyncJob implements Job {
 
     List<MetadataVersion> versions =
         metadataSyncPreProcessor.handleMetadataVersions(context, progress);
+
+    // Clear the security context is clean (no user authenticated) before the metadata sync.
+    // For more info, see: https://dhis2.atlassian.net/browse/DHIS2-19658
+    SecurityContext secContext = SecurityContextHolder.createEmptyContext();
+    SecurityContextHolder.setContext(secContext);
 
     handleMetadataSync(context, versions, progress);
 


### PR DESCRIPTION
https://app.clickup.com/t/86994xzb8

See https://dhis2.atlassian.net/browse/DHIS2-19658