### PR TITLE
[OCG] Fix: Tracker program "Skip synchronization" not working for attributes or dataValues

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -193,9 +193,9 @@ public class TrackerSynchronization implements DataSynchronizationWithPaging {
   }
 
   /**
-   * Filters out data marked with the skip synchronization flag from the TEIs structure. This includes:
-   * TrackedEntityInstances and Enrollments attributes with skipSynchronization and Event data values where the data
-   * element is in psdeSkipMap
+   * Filters out data marked with the skip synchronization flag from the TEIs structure. This
+   * includes: TrackedEntityInstances and Enrollments attributes with skipSynchronization and Event
+   * data values where the data element is in psdeSkipMap
    *
    * @param teis The TrackedEntityInstances to filter
    * @param psdeSkipMap Map of program stage ID to data elements IDs that should be skipped

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -171,7 +171,8 @@ public class TrackerSynchronization implements DataSynchronizationWithPaging {
     List<TrackedEntityInstance> dtoTeis =
         teiService.getTrackedEntityInstances(
             queryParams, TrackedEntityInstanceParams.DATA_SYNCHRONIZATION, true, true);
-    final Map<String, Set<String>> psdeSkipMap = programStageDataElementService
+    final Map<String, Set<String>> psdeSkipMap =
+        programStageDataElementService
             .getProgramStageDataElementsWithSkipSynchronizationSetToTrue();
 
     if (log.isDebugEnabled()) {
@@ -192,46 +193,54 @@ public class TrackerSynchronization implements DataSynchronizationWithPaging {
   }
 
   /**
-   * Filters out data marked with skip synchronization flag from the TEIs structure.
-   * This includes:
-   * - TEI attributes with skipSynchronization=true
-   * - Enrollment attributes with skipSynchronization=true
-   * - Event data values where the data element is in the skip map
+   * Filters out data marked with the skip synchronization flag from the TEIs structure. This includes:
+   * TrackedEntityInstances and Enrollments attributes with skipSynchronization and Event data values where the data
+   * element is in psdeSkipMap
    *
    * @param teis The TrackedEntityInstances to filter
    * @param psdeSkipMap Map of program stage ID to data elements IDs that should be skipped
    */
   private void filterDataWithSkipSynchronizationFlag(
-          TrackedEntityInstances teis, Map<String, Set<String>> psdeSkipMap) {
-    teis.getTrackedEntityInstances().forEach(tei -> {
-      filterTeiAttributes(tei);
+      TrackedEntityInstances teis, Map<String, Set<String>> psdeSkipMap) {
+    teis.getTrackedEntityInstances()
+        .forEach(
+            tei -> {
+              filterTeiAttributes(tei);
 
-      tei.getEnrollments().forEach(enrollment -> {
-        filterEnrollmentAttributes(enrollment);
-        filterEnrollmentEvents(enrollment, psdeSkipMap);
-      });
-  });
+              tei.getEnrollments()
+                  .forEach(
+                      enrollment -> {
+                        filterEnrollmentAttributes(enrollment);
+                        filterEnrollmentEvents(enrollment, psdeSkipMap);
+                      });
+            });
   }
 
   private void filterTeiAttributes(TrackedEntityInstance tei) {
-    tei.setAttributes(tei.getAttributes().stream()
+    tei.setAttributes(
+        tei.getAttributes().stream()
             .filter(att -> !att.isSkipSynchronization())
             .collect(Collectors.toList()));
   }
 
   private void filterEnrollmentAttributes(Enrollment enrollment) {
-    enrollment.setAttributes(enrollment.getAttributes().stream()
+    enrollment.setAttributes(
+        enrollment.getAttributes().stream()
             .filter(att -> !att.isSkipSynchronization())
             .collect(Collectors.toList()));
   }
 
   private void filterEnrollmentEvents(Enrollment enrollment, Map<String, Set<String>> psdeSkipMap) {
-    enrollment.getEvents().forEach(event -> {
-      Set<String> skipIds = psdeSkipMap.get(event.getProgramStage());
-      event.setDataValues(event.getDataValues().stream()
-              .filter(dv -> skipIds == null || !skipIds.contains(dv.getDataElement()))
-              .collect(Collectors.toSet()));
-    });
+    enrollment
+        .getEvents()
+        .forEach(
+            event -> {
+              Set<String> skipIds = psdeSkipMap.get(event.getProgramStage());
+              event.setDataValues(
+                  event.getDataValues().stream()
+                      .filter(dv -> skipIds == null || !skipIds.contains(dv.getDataElement()))
+                      .collect(Collectors.toSet()));
+            });
   }
 
   private boolean sendSyncRequest(


### PR DESCRIPTION
Closes Issue: [[1224] Patients' first and last names are not ignored during synchronisation](https://app.clickup.com/t/869a1tgyt)

Jira report: https://dhis2.atlassian.net/browse/DHIS2-19964

When performing a "Tracker programs data sync" or "Metadata synchronization" scheduler job the values of attributes and stage dataElements with Skip synchronization set to true are send to the remote server nonetheless.

The TrackedEntityInstances object always has `skipSynchronization == false` for the event dataValues.