### PR TITLE
[WIDP] fix: add create audit log

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -200,9 +200,6 @@ public class DefaultDataValueService implements DataValueService {
               CurrentUserUtil.getCurrentUsername(),
               ChangeLogType.DELETE);
 
-      new DataValueAudit(
-              dataValue, dataValue.getValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
-
       dataValueAuditService.addDataValueAudit(dataValueAudit);
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -139,14 +139,14 @@ public class DefaultDataValueService implements DataValueService {
       softDelete.setLastUpdated(currentDate);
 
       dataValueStore.updateDataValue(softDelete);
+    }
 
-      if (config.isEnabled(CHANGELOG_AGGREGATE)) {
-        DataValueAudit dataValueAudit =
-            new DataValueAudit(
-                dataValue, dataValue.getValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
+    if (config.isEnabled(CHANGELOG_AGGREGATE)) {
+      DataValueAudit dataValueAudit =
+              new DataValueAudit(
+                      dataValue, dataValue.getAuditValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
 
-        dataValueAuditService.addDataValueAudit(dataValueAudit);
-      }
+      dataValueAuditService.addDataValueAudit(dataValueAudit);
     }
 
     return true;
@@ -199,6 +199,9 @@ public class DefaultDataValueService implements DataValueService {
               dataValue.getAuditValue(),
               CurrentUserUtil.getCurrentUsername(),
               ChangeLogType.DELETE);
+
+      new DataValueAudit(
+              dataValue, dataValue.getValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
 
       dataValueAuditService.addDataValueAudit(dataValueAudit);
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -143,8 +143,8 @@ public class DefaultDataValueService implements DataValueService {
 
     if (config.isEnabled(CHANGELOG_AGGREGATE)) {
       DataValueAudit dataValueAudit =
-              new DataValueAudit(
-                      dataValue, dataValue.getAuditValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
+          new DataValueAudit(
+              dataValue, dataValue.getAuditValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
 
       dataValueAuditService.addDataValueAudit(dataValueAudit);
     }


### PR DESCRIPTION
[Modification to display information on who entered the first values in a dataset](https://app.clickup.com/t/869a3wvt5)

### :memo: Implementation
- move "CREATE" audit log so that initialization and re-initialization are audited

Additional references related to the issue
- reported issue: https://dhis2.atlassian.net/browse/DHIS2-13495
    - indicated fix in the issue does not solve the underlying issue. "CREATE" log displayed in the new data entry app is generated and info about initialization is still lost after value updates
    
- similar issue reported: [community](https://community.dhis2.org/t/audit-unexpected-bahaviour-on-dataentry/37714) and the resulting jira ticket [jira](https://dhis2.atlassian.net/browse/DHIS2-7959)
    - it was stated that one concern with "CREATE" audit logs is the table size