### PR TITLE
[OCG] Fix: mapViews metadata sync fails with ConstraintViolationException due to duplicate key

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -44,7 +44,10 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -228,6 +231,8 @@ public class DefaultMetadataExportService implements MetadataExportService {
     Map<Class<? extends IdentifiableObject>, List<? extends IdentifiableObject>> metadata =
         getMetadata(params);
 
+    filterMapViewObjects(metadata);
+
     for (Map.Entry<Class<? extends IdentifiableObject>, List<? extends IdentifiableObject>> entry :
         metadata.entrySet()) {
       FieldFilterParams<?> fieldFilterParams =
@@ -246,6 +251,32 @@ public class DefaultMetadataExportService implements MetadataExportService {
     }
 
     return rootNode;
+  }
+
+  private void filterMapViewObjects(Map<Class<? extends IdentifiableObject>, List<? extends IdentifiableObject>> metadata) {
+    List<? extends IdentifiableObject> mapObjects = metadata.get(org.hisp.dhis.mapping.Map.class);
+    List<? extends IdentifiableObject> mapViewObjects = metadata.get(org.hisp.dhis.mapping.MapView.class);
+
+    if (mapObjects != null && mapViewObjects != null) {
+      Set<String> mapViewIdsInMap = new HashSet<>();
+      for (IdentifiableObject mapObj : mapObjects) {
+        if (mapObj instanceof org.hisp.dhis.mapping.Map) {
+          org.hisp.dhis.mapping.Map map = (org.hisp.dhis.mapping.Map) mapObj;
+          for (org.hisp.dhis.mapping.MapView mapView : map.getMapViews()) {
+            mapViewIdsInMap.add(mapView.getUid());
+          }
+        }
+      }
+
+      mapViewObjects = mapViewObjects.stream()
+              .filter(obj -> !mapViewIdsInMap.contains(obj.getUid()))
+              .collect(Collectors.toList());
+      if (mapViewObjects.isEmpty()) {
+        metadata.remove(org.hisp.dhis.mapping.MapView.class);
+      } else {
+        metadata.put(org.hisp.dhis.mapping.MapView.class, mapViewObjects);
+      }
+    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -44,10 +44,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.HashSet;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -231,7 +228,9 @@ public class DefaultMetadataExportService implements MetadataExportService {
     Map<Class<? extends IdentifiableObject>, List<? extends IdentifiableObject>> metadata =
         getMetadata(params);
 
-    filterMapViewObjects(metadata);
+    if (metadata.containsKey(org.hisp.dhis.mapping.Map.class)) {
+      metadata.remove(org.hisp.dhis.mapping.MapView.class);
+    }
 
     for (Map.Entry<Class<? extends IdentifiableObject>, List<? extends IdentifiableObject>> entry :
         metadata.entrySet()) {
@@ -251,32 +250,6 @@ public class DefaultMetadataExportService implements MetadataExportService {
     }
 
     return rootNode;
-  }
-
-  private void filterMapViewObjects(Map<Class<? extends IdentifiableObject>, List<? extends IdentifiableObject>> metadata) {
-    List<? extends IdentifiableObject> mapObjects = metadata.get(org.hisp.dhis.mapping.Map.class);
-    List<? extends IdentifiableObject> mapViewObjects = metadata.get(org.hisp.dhis.mapping.MapView.class);
-
-    if (mapObjects != null && mapViewObjects != null) {
-      Set<String> mapViewIdsInMap = new HashSet<>();
-      for (IdentifiableObject mapObj : mapObjects) {
-        if (mapObj instanceof org.hisp.dhis.mapping.Map) {
-          org.hisp.dhis.mapping.Map map = (org.hisp.dhis.mapping.Map) mapObj;
-          for (org.hisp.dhis.mapping.MapView mapView : map.getMapViews()) {
-            mapViewIdsInMap.add(mapView.getUid());
-          }
-        }
-      }
-
-      mapViewObjects = mapViewObjects.stream()
-              .filter(obj -> !mapViewIdsInMap.contains(obj.getUid()))
-              .collect(Collectors.toList());
-      if (mapViewObjects.isEmpty()) {
-        metadata.remove(org.hisp.dhis.mapping.MapView.class);
-      } else {
-        metadata.put(org.hisp.dhis.mapping.MapView.class, mapViewObjects);
-      }
-    }
   }
 
   @Override


### PR DESCRIPTION
## Links
Task: [[1209] Test maps synchronization](https://app.clickup.com/t/869a6ubnc)

## Description

The code of the PR referenced in the task is not used when running syncs, instead is used for Metadata dependency export of Dasboards.

The metadata version object is created by `DefaultMetadataExportService.getMetadataAsObjectNode`. Issue is that it includes both `Map` and `MapView` objects.

Now, before processing the retrieved metadata, its checked to contain Maps objects. If it so then the standalone MapView objects are deleted as they are in the Maps.