### PR TITLE
fix: Initial dataValue audit log [DHIS2-20047]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -142,14 +142,14 @@ public class DefaultDataValueService implements DataValueService {
       softDelete.setLastUpdated(currentDate);
 
       dataValueStore.updateDataValue(softDelete);
+    }
 
-      if (config.isEnabled(CHANGELOG_AGGREGATE)) {
-        DataValueAudit dataValueAudit =
-            new DataValueAudit(
-                dataValue, dataValue.getValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
+    if (config.isEnabled(CHANGELOG_AGGREGATE)) {
+      DataValueAudit dataValueAudit =
+          new DataValueAudit(
+              dataValue, dataValue.getValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
 
-        dataValueAuditService.addDataValueAudit(dataValueAudit);
-      }
+      dataValueAuditService.addDataValueAudit(dataValueAudit);
     }
 
     return true;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -147,7 +147,7 @@ public class DefaultDataValueService implements DataValueService {
     if (config.isEnabled(CHANGELOG_AGGREGATE)) {
       DataValueAudit dataValueAudit =
           new DataValueAudit(
-              dataValue, dataValue.getValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
+              dataValue, dataValue.getAuditValue(), dataValue.getStoredBy(), ChangeLogType.CREATE);
 
       dataValueAuditService.addDataValueAudit(dataValueAudit);
     }


### PR DESCRIPTION
# Background
Currently, when entering a value in the Data Entry app:
- The first value is stored as a data value, including metadata (who entered it, when).
- However, when the value is changed, the initial information is replaced and the audit log only stores the new value and who updated it.
- As a result, the information about who created the initial value and when is lost as soon as the value is updated.

# Issue
The root issue is the placement of the audit creation logic when initializing the dataValue.
- Currently: audit creation only happens when re-initiating after soft deletion

# Fix
Move the audit creation outside of condition, ensuring that an audit entry is always created.

## Additional References
- similar issue reported: [community](https://community.dhis2.org/t/audit-unexpected-bahaviour-on-dataentry/37714) and the resulting jira ticket [jira](https://dhis2.atlassian.net/browse/DHIS2-7959)
    - it was stated that one concern with "CREATE" audit logs is the table size