### PR TITLE
[OCG] Fix: uninitialized 'relatives' causes NullPointerException

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -452,7 +452,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
 
       if (hasRelativePeriods()) {
         items.addAll(
-                getRelatives().getRelativePeriods(date, format, dynamicNames, FINANCIAL_YEAR_OCTOBER));
+            getRelatives().getRelativePeriods(date, format, dynamicNames, FINANCIAL_YEAR_OCTOBER));
       }
 
       type = DimensionType.PERIOD;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -452,7 +452,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
 
       if (hasRelativePeriods()) {
         items.addAll(
-            relatives.getRelativePeriods(date, format, dynamicNames, FINANCIAL_YEAR_OCTOBER));
+                getRelatives().getRelativePeriods(date, format, dynamicNames, FINANCIAL_YEAR_OCTOBER));
       }
 
       type = DimensionType.PERIOD;


### PR DESCRIPTION

## Links
Task: [[1238] Error in API extraction of csv data from visualization](https://app.clickup.com/t/869ab8h05)

## Description

Retrieving the data of a pivot table with relative periods via `api/visualizations/UID/data` or `api/visualizations/UID/data.csv` caused a NullPointerException because `relatives` was uninitialized. Switched to `getRelatives()` as it returns  a new `RelativePeriods` if relatives is `null`.

Note: had to base the PR on `fix/visualizations-relative-periods-import-error` because it updates `getRelatives()` with code needed for this fix.