### PR TITLE
[WIDP] fix: restore isTwoFactorEnabled property

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -443,7 +443,8 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
     this.password = password;
   }
 
-  @JsonIgnore
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public boolean isTwoFactorEnabled() {
     return this.twoFactorType != null && this.twoFactorType.isEnabled();
   }


### PR DESCRIPTION
**Task**: https://app.clickup.com/t/869adzc4b

**Background**: In <2.41 we had the boolean property `twoFA` which was used in maintenance tasks. In 2.42 it was renamed to `isTwoFactorEnabled` and removed from responses.

**Implementation**: This PR includes `isTwoFactorEnabled` in the responses.

This is a short-term patch and we should consider a future-proof solution that converges with upstream.