### PR TITLE
Fix not unique key name in job configuration when two jobs at same moment: use nanoseconds instead of milliseconds

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -39,6 +39,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.UUID;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.Getter;
@@ -208,7 +209,11 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
   public JobConfiguration(
       @CheckForNull String name, @Nonnull JobType type, @CheckForNull String executedBy) {
     this.name =
-        name == null || name.isEmpty() ? "%s (%d)".formatted(type.name(), System.nanoTime()) : name;
+        (name == null || name.isEmpty())
+            ? "%s (%d-%s)"
+                .formatted(
+                    type.name(), System.nanoTime(), UUID.randomUUID().toString().substring(0, 8))
+            : name;
     this.jobType = type;
     this.executedBy = executedBy;
     setAutoFields();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -208,9 +208,7 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
   public JobConfiguration(
       @CheckForNull String name, @Nonnull JobType type, @CheckForNull String executedBy) {
     this.name =
-        name == null || name.isEmpty()
-            ? "%s (%d)".formatted(type.name(), Instant.now().toEpochMilli())
-            : name;
+        name == null || name.isEmpty() ? "%s (%d)".formatted(type.name(), System.nanoTime()) : name;
     this.jobType = type;
     this.executedBy = executedBy;
     setAutoFields();


### PR DESCRIPTION
Task: https://app.clickup.com/t/869a73yk3

In d2-logger using event program logger: Error found in v2.41.5 using new tracker endpoint importing events to an event program asynchronously (ticket https://dhis2.atlassian.net/browse/DHIS2-20098). 

```
db-1       | 2025-09-08 16:45:26.991 CEST [179] ERROR:  duplicate key value violates unique constraint "uk_rqkhk3ebvk1kflf7qigbaxeyp"
db-1       | 2025-09-08 16:45:26.991 CEST [179] DETAIL:  Key (name)=(TRACKER_IMPORT_JOB (1757342726927)) already exists.
db-1       | 2025-09-08 16:45:26.991 CEST [179] STATEMENT:  insert into jobconfiguration (uid, code, created, lastUpdated, lastupdatedby, name, queuename, queueposition, cronExpression, delay, jobtype, schedulingtype, jobstatus, lastexecutedstatus, executedby, enabled, jsonbjobparameters, jobconfigurationid) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
```

We don't use await in the logger because we don't want to stop the script execution to wait for each log. 

Key name duplicated because they use timestamp to build unique name for the job: https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java#L208

- [x] Use nanoseconds instead of milliseconds for job configuration name
