### PR TITLE
[OCBA] feat: Increase dataPush client timeout

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
@@ -119,7 +119,8 @@ public class RouteService {
         new HttpComponentsClientHttpRequestFactory();
     requestFactory.setConnectionRequestTimeout(1_000);
     requestFactory.setConnectTimeout(5_000);
-    requestFactory.setReadTimeout(30_000);
+    // Used by restTemplate in SyncUtils.java. Increase from the default 30 seconds to 20 minutes
+    requestFactory.setReadTimeout(20 * 60_000);
     requestFactory.setBufferRequestBody(true);
 
     PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();


### PR DESCRIPTION
https://app.clickup.com/t/869apbahc

This has already been fixed in 40.10, so this is just a workaround while we are using earlier versions.