### PR TITLE
Preserve period order when cleaning raw periods

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.common;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -712,9 +711,9 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
         rawPeriods = new ArrayList<>();
         rawPeriods.addAll(
             getPeriods().stream()
-                .filter(period -> !rawPeriods.contains(period.getDimensionItem()))
-                .map(period -> period.getDimensionItem())
-                .collect(toSet()));
+                .map(Period::getDimensionItem)
+                .distinct()
+                .collect(Collectors.toList()));
       }
 
       if (isNotEmpty(rawPeriods)) {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseAnalyticalObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseAnalyticalObjectTest.java
@@ -38,16 +38,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.eventchart.EventChart;
 import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeDimension;
@@ -229,6 +233,38 @@ class BaseAnalyticalObjectTest {
     assertEquals(sameDimensionUid, baseDimensionalObject2.getDimension());
     assertNotNull(baseDimensionalObject2.getProgramStage());
     assertEquals(programStage2, baseDimensionalObject2.getProgramStage());
+  }
+
+  @Test
+  void testGetDimensionalObjectPeriodOrderPreservedWhenRawPeriodsCleaned() {
+    Visualization visualization = new Visualization("visualization");
+
+    Period january2023 = PeriodType.getPeriodFromIsoString("202301");
+    Period february2023 = PeriodType.getPeriodFromIsoString("202302");
+    Period march2023 = PeriodType.getPeriodFromIsoString("202303");
+
+    visualization.setPeriods(
+        new ArrayList<>(List.of(january2023, february2023, march2023)));
+    visualization.setRawPeriods(new ArrayList<>());
+
+    Optional<DimensionalObject> periodDimension =
+        visualization.getDimensionalObject(DimensionalObject.PERIOD_DIM_ID);
+
+    assertTrue(periodDimension.isPresent());
+
+    List<String> expectedOrder =
+        visualization.getPeriods().stream()
+            .map(Period::getDimensionItem)
+            .collect(Collectors.toList());
+
+    List<String> actualOrder =
+        ((BaseDimensionalObject) periodDimension.get())
+            .getItems()
+            .stream()
+            .map(DimensionalItemObject::getDimensionItem)
+            .collect(Collectors.toList());
+
+    assertEquals(expectedOrder, actualOrder);
   }
 
   private TrackedEntityDataElementDimension stubTrackedEntityDataElementDimension(


### PR DESCRIPTION
## Summary
- ensure BaseAnalyticalObject preserves the original period sequence when rebuilding rawPeriods
- add a unit test covering period order retention after cleaning rawPeriods

## Testing
- mvn -f dhis-2/pom.xml -pl dhis-api -am test -Dtest=org.hisp.dhis.common.BaseAnalyticalObjectTest#testGetDimensionalObjectPeriodOrderPreservedWhenRawPeriodsCleaned *(fails: could not download dependencies from remote mirror)*

------
https://chatgpt.com/codex/tasks/task_b_68dfba1702288323bf260519ffb17cdd