### PR TITLE
[WIDP] fix: keep periods order for visualizations without rawPeriods

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.common;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -66,6 +65,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -714,7 +714,7 @@ public abstract class BaseAnalyticalObject extends BaseNameableObject implements
             getPeriods().stream()
                 .filter(period -> !rawPeriods.contains(period.getDimensionItem()))
                 .map(period -> period.getDimensionItem())
-                .collect(toSet()));
+                .collect(Collectors.toCollection(LinkedHashSet::new)));
       }
 
       if (isNotEmpty(rawPeriods)) {


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869an2hdd

Using `toSet()` results in the periods returned being in incorrect order. This causes a lot of visualizations to have their rows with dimension = PE in incorrect order, i.e. years scrambled.