### PR TITLE
feat: 2FA enforcement

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-api</artifactId>

--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-api</artifactId>

--- a/dhis-2/dhis-services/dhis-service-acl/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-acl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-acl</artifactId>

--- a/dhis-2/dhis-services/dhis-service-acl/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-acl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-acl</artifactId>

--- a/dhis-2/dhis-services/dhis-service-administration/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-administration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-administration</artifactId>

--- a/dhis-2/dhis-services/dhis-service-administration/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-administration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-administration</artifactId>

--- a/dhis-2/dhis-services/dhis-service-analytics/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-analytics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-analytics</artifactId>

--- a/dhis-2/dhis-services/dhis-service-analytics/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-analytics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-analytics</artifactId>

--- a/dhis-2/dhis-services/dhis-service-audit-consumer/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-audit-consumer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-audit-consumer</artifactId>

--- a/dhis-2/dhis-services/dhis-service-audit-consumer/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-audit-consumer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-audit-consumer</artifactId>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-core</artifactId>

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-core</artifactId>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
@@ -27,10 +27,8 @@
  */
 package org.hisp.dhis.security.spring2fa;
 
-import static org.hisp.dhis.security.twofa.TwoFactorAuthService.TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME;
 import static org.hisp.dhis.security.twofa.TwoFactorAuthUtils.isValid2FACode;
 
-import java.util.Set;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
@@ -105,10 +103,6 @@ public class TwoFactorAuthenticationProvider extends DaoAuthenticationProvider {
     // Validate that the user is not configured for external auth only
     checkExternalAuth(userDetails, username);
 
-    // If the user’s role requires 2FA enrollment but they haven’t set it up, throw
-    // an exception.
-    checkTwoFactorEnrolment(userDetails);
-
     // Handle two-factor authentication validations.
     checkTwoFactorAuthentication(auth, userDetails);
 
@@ -131,15 +125,6 @@ public class TwoFactorAuthenticationProvider extends DaoAuthenticationProvider {
           username);
       throw new BadCredentialsException(
           "Invalid login method, user is using external authentication");
-    }
-  }
-
-  private void checkTwoFactorEnrolment(UserDetails userDetails) {
-    boolean has2FARestriction =
-        userDetails.hasAnyRestrictions(Set.of(TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME));
-    if (!userDetails.isTwoFactorEnabled() && has2FARestriction) {
-      throw new TwoFactorAuthenticationEnrolmentException(
-          "User must setup two-factor authentication first before logging in");
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-data-exchange</artifactId>

--- a/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-data-exchange</artifactId>

--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-dxf2</artifactId>

--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-dxf2</artifactId>

--- a/dhis-2/dhis-services/dhis-service-event-hook/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-event-hook/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-event-hook</artifactId>

--- a/dhis-2/dhis-services/dhis-service-event-hook/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-event-hook/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-event-hook</artifactId>

--- a/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-field-filtering</artifactId>

--- a/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-field-filtering</artifactId>

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-metadata-workflow</artifactId>

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-metadata-workflow</artifactId>

--- a/dhis-2/dhis-services/dhis-service-node/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-node/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-node</artifactId>

--- a/dhis-2/dhis-services/dhis-service-node/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-node/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-node</artifactId>

--- a/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-program-rule</artifactId>

--- a/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-program-rule/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-program-rule</artifactId>

--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-reporting</artifactId>

--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-reporting</artifactId>

--- a/dhis-2/dhis-services/dhis-service-schema/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-schema/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-schema</artifactId>

--- a/dhis-2/dhis-services/dhis-service-schema/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-schema/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-schema</artifactId>

--- a/dhis-2/dhis-services/dhis-service-setting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-setting/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-setting</artifactId>

--- a/dhis-2/dhis-services/dhis-service-setting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-setting/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-setting</artifactId>

--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
   <artifactId>dhis-service-tracker</artifactId>
   <packaging>jar</packaging>

--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
   <artifactId>dhis-service-tracker</artifactId>
   <packaging>jar</packaging>

--- a/dhis-2/dhis-services/dhis-service-validation/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-service-validation</artifactId>

--- a/dhis-2/dhis-services/dhis-service-validation/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-service-validation</artifactId>

--- a/dhis-2/dhis-services/pom.xml
+++ b/dhis-2/dhis-services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-services</artifactId>

--- a/dhis-2/dhis-services/pom.xml
+++ b/dhis-2/dhis-services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-services</artifactId>

--- a/dhis-2/dhis-support/dhis-support-artemis/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-artemis/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-artemis</artifactId>

--- a/dhis-2/dhis-support/dhis-support-artemis/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-artemis/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-artemis</artifactId>

--- a/dhis-2/dhis-support/dhis-support-audit/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-audit</artifactId>

--- a/dhis-2/dhis-support/dhis-support-audit/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-audit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-audit</artifactId>

--- a/dhis-2/dhis-support/dhis-support-cache-invalidation/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-cache-invalidation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-cache-invalidation</artifactId>

--- a/dhis-2/dhis-support/dhis-support-cache-invalidation/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-cache-invalidation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-cache-invalidation</artifactId>

--- a/dhis-2/dhis-support/dhis-support-commons/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-commons</artifactId>

--- a/dhis-2/dhis-support/dhis-support-commons/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-commons</artifactId>

--- a/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-db-migration</artifactId>

--- a/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-db-migration</artifactId>

--- a/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-expression-parser</artifactId>

--- a/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-expression-parser</artifactId>

--- a/dhis-2/dhis-support/dhis-support-external/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-external/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-external</artifactId>

--- a/dhis-2/dhis-support/dhis-support-external/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-external/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-external</artifactId>

--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-hibernate</artifactId>

--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-hibernate</artifactId>

--- a/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-jdbc</artifactId>

--- a/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-jdbc</artifactId>

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-system</artifactId>

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-system</artifactId>

--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support-test</artifactId>

--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-support</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support-test</artifactId>

--- a/dhis-2/dhis-support/pom.xml
+++ b/dhis-2/dhis-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-support</artifactId>

--- a/dhis-2/dhis-support/pom.xml
+++ b/dhis-2/dhis-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-support</artifactId>

--- a/dhis-2/dhis-test-coverage/pom.xml
+++ b/dhis-2/dhis-test-coverage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-test-coverage</artifactId>

--- a/dhis-2/dhis-test-coverage/pom.xml
+++ b/dhis-2/dhis-test-coverage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-test-coverage</artifactId>

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-test-integration</artifactId>

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-test-integration</artifactId>

--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-test-web-api</artifactId>

--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-test-web-api</artifactId>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -404,6 +404,31 @@ class AuthenticationControllerTest extends DhisAuthenticationApiTest {
     assertEquals("/dhis-web-login", redirectResponse.getRedirectedUrl());
   }
 
+  @Test
+  void testBasicAuthBlockedFor2FARestrictionUser() throws Exception {
+    User user = createUserWithAuth("basicauth2fa", "ALL");
+    UserRole role = user.getUserRoles().iterator().next();
+    role.setRestrictions(Set.of(TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME));
+    userService.updateUserRole(role);
+
+    String basicAuth =
+        "Basic " + java.util.Base64.getEncoder().encodeToString("basicauth2fa:district".getBytes());
+
+    // API requests with Basic Auth should be blocked (403)
+    MockHttpServletResponse blockedResponse =
+        mvc.perform(get("/api/users").header("Authorization", basicAuth))
+            .andExpect(status().isForbidden())
+            .andReturn()
+            .getResponse();
+
+    Map<String, Object> blockedBody =
+        objectMapper.readValue(blockedResponse.getContentAsString(), Map.class);
+    assertEquals("REQUIRES_TWO_FACTOR_ENROLMENT", blockedBody.get("loginStatus"));
+
+    // Allowed endpoints should still work with Basic Auth
+    mvc.perform(get("/api/me").header("Authorization", basicAuth)).andExpect(status().isOk());
+  }
+
   private void loginWith2FACode(String code) {
     JsonLoginResponse ok2FaCodeResponse =
         POST(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -28,13 +28,19 @@
 package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.common.CodeGenerator.generateSecureRandomBytes;
+import static org.hisp.dhis.security.twofa.TwoFactorAuthService.TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Calendar;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.http.Cookie;
 import org.hisp.dhis.security.twofa.TwoFactorAuthService;
 import org.hisp.dhis.security.twofa.TwoFactorAuthService.Email2FACode;
 import org.hisp.dhis.security.twofa.TwoFactorType;
@@ -42,6 +48,7 @@ import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisAuthenticationApiTest;
 import org.hisp.dhis.webapi.json.domain.JsonLoginResponse;
@@ -52,6 +59,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.session.SessionRegistry;
 
 /**
@@ -62,6 +70,7 @@ class AuthenticationControllerTest extends DhisAuthenticationApiTest {
 
   @Autowired SystemSettingManager systemSettingManager;
   @Autowired private SessionRegistry sessionRegistry;
+  @Autowired private ObjectMapper objectMapper;
 
   @AfterEach
   void tearDown() {
@@ -315,6 +324,84 @@ class AuthenticationControllerTest extends DhisAuthenticationApiTest {
 
     assertNotNull(actual);
     assertEquals("admin", actual.getUsername());
+  }
+
+  @Test
+  void testLoginWith2FARestrictionAllowsOnlySetupEndpoints() throws Exception {
+    User user = createUserWithAuth("requires2fa", "ALL");
+    UserRole role = user.getUserRoles().iterator().next();
+    role.setRestrictions(Set.of(TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME));
+    userService.updateUserRole(role);
+
+    MockHttpServletResponse loginResponse =
+        mvc.perform(
+                post("/auth/login")
+                    .contentType("application/json")
+                    .content("{\"username\":\"requires2fa\",\"password\":\"district\"}"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse();
+
+    Map<String, Object> loginBody =
+        objectMapper.readValue(loginResponse.getContentAsString(), Map.class);
+    assertEquals("REQUIRES_TWO_FACTOR_ENROLMENT", loginBody.get("loginStatus"));
+
+    Cookie sessionCookie = loginResponse.getCookie("JSESSIONID");
+    assertNotNull(sessionCookie);
+
+    mvc.perform(get("/2fa/enabled").cookie(sessionCookie)).andExpect(status().isOk());
+
+    MockHttpServletResponse blockedResponse =
+        mvc.perform(get("/users").cookie(sessionCookie))
+            .andExpect(status().isForbidden())
+            .andReturn()
+            .getResponse();
+
+    Map<String, Object> blockedBody =
+        objectMapper.readValue(blockedResponse.getContentAsString(), Map.class);
+    assertEquals("REQUIRES_TWO_FACTOR_ENROLMENT", blockedBody.get("loginStatus"));
+
+    mvc.perform(post("/2fa/enrollTOTP2FA").cookie(sessionCookie)).andExpect(status().isOk());
+
+    User userWithSecret = userService.getUserByUsername("requires2fa");
+    String code = new Totp(userWithSecret.getSecret()).now();
+
+    mvc.perform(
+            post("/2fa/enable")
+                .cookie(sessionCookie)
+                .contentType("application/json")
+                .content("{\"code\":\"%s\"}".formatted(code)))
+        .andExpect(status().isOk());
+
+    mvc.perform(get("/users").cookie(sessionCookie)).andExpect(status().isOk());
+  }
+
+  @Test
+  void testLoginWith2FARestrictionRedirectsAppNavigationToLoginPage() throws Exception {
+    User user = createUserWithAuth("requires2faredirect", "ALL");
+    UserRole role = user.getUserRoles().iterator().next();
+    role.setRestrictions(Set.of(TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME));
+    userService.updateUserRole(role);
+
+    MockHttpServletResponse loginResponse =
+        mvc.perform(
+                post("/auth/login")
+                    .contentType("application/json")
+                    .content("{\"username\":\"requires2faredirect\",\"password\":\"district\"}"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse();
+
+    Cookie sessionCookie = loginResponse.getCookie("JSESSIONID");
+    assertNotNull(sessionCookie);
+
+    MockHttpServletResponse redirectResponse =
+        mvc.perform(get("/apps/Homepage-App/").cookie(sessionCookie))
+            .andExpect(status().is3xxRedirection())
+            .andReturn()
+            .getResponse();
+
+    assertEquals("/dhis-web-login", redirectResponse.getRedirectedUrl());
   }
 
   private void loginWith2FACode(String code) {

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-web-api</artifactId>

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-web-api</artifactId>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -37,7 +37,6 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationEnrolmentException;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationException;
 import org.hisp.dhis.security.spring2fa.TwoFactorCodeDeliveryFailedException;
 import org.hisp.dhis.security.spring2fa.TwoFactorCodeSentException;
@@ -165,6 +164,12 @@ public class AuthenticationController {
             new InteractiveAuthenticationSuccessEvent(authenticationResult, this.getClass()));
       }
 
+      if (requiresTwoFactorEnrolment(authenticationResult)) {
+        TwoFactorSetupSessionAccess.markRequired(request);
+        return LoginResponse.builder().loginStatus(STATUS.REQUIRES_TWO_FACTOR_ENROLMENT).build();
+      }
+
+      TwoFactorSetupSessionAccess.clear(request);
       return LoginResponse.builder().loginStatus(STATUS.SUCCESS).redirectUrl(redirectUrl).build();
 
     } catch (TwoFactorCodeSentRateLimitException e) {
@@ -189,11 +194,6 @@ public class AuthenticationController {
         return LoginResponse.builder().loginStatus(STATUS.INCORRECT_TWO_FACTOR_CODE_SMS).build();
       }
       return LoginResponse.builder().loginStatus(STATUS.INCORRECT_TWO_FACTOR_CODE_TOTP).build();
-    } catch (TwoFactorAuthenticationEnrolmentException e) {
-      Authentication authToken = createAuthenticationToken(request, loginRequest);
-      publishAuthenticationFailureEvent(authToken, e);
-      return LoginResponse.builder().loginStatus(STATUS.REQUIRES_TWO_FACTOR_ENROLMENT).build();
-
     } catch (CredentialsExpiredException e) {
       return LoginResponse.builder().loginStatus(STATUS.PASSWORD_EXPIRED).build();
     } catch (LockedException e) {
@@ -294,6 +294,14 @@ public class AuthenticationController {
               auth, new BadCredentialsException("2FA authentication failed", exception));
       this.eventPublisher.publishEvent(failureEvent);
     }
+  }
+
+  private boolean requiresTwoFactorEnrolment(Authentication authenticationResult) {
+    if (!(authenticationResult.getPrincipal() instanceof UserDetails userDetails)) {
+      return false;
+    }
+
+    return TwoFactorSetupSessionAccess.requiresTwoFactorEnrolment(userDetails);
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.security.twofa.TwoFactorAuthService;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -74,6 +75,7 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 public class TwoFactorController {
   private final TwoFactorAuthService twoFactorAuthService;
+  private final UserService userService;
 
   @PostMapping(value = "/enrollTOTP2FA")
   @ResponseStatus(HttpStatus.OK)
@@ -182,6 +184,8 @@ public class TwoFactorController {
     }
     twoFactorAuthService.enable2FA(currentUser.getUsername(), code, currentUser);
     TwoFactorSetupSessionAccess.clear(request);
+    User freshUser = userService.getUserByUsername(currentUser.getUsername());
+    TwoFactorSetupSessionAccess.refreshSecurityContext(freshUser, request);
     return ok("2FA was enabled successfully");
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
@@ -36,6 +36,7 @@ import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -171,13 +172,16 @@ public class TwoFactorController {
       consumes = {"text/*", "application/*"})
   @ResponseStatus(HttpStatus.OK)
   public WebMessage enable(
-      @RequestBody Map<String, String> body, @CurrentUser(required = true) UserDetails currentUser)
+      @RequestBody Map<String, String> body,
+      HttpServletRequest request,
+      @CurrentUser(required = true) UserDetails currentUser)
       throws ForbiddenException, ConflictException {
     String code = body.get("code");
     if (Strings.isNullOrEmpty(code)) {
       throw new ConflictException(ErrorCode.E3050);
     }
     twoFactorAuthService.enable2FA(currentUser.getUsername(), code, currentUser);
+    TwoFactorSetupSessionAccess.clear(request);
     return ok("2FA was enabled successfully");
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorSetupSessionAccess.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorSetupSessionAccess.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.security;
+
+import static org.hisp.dhis.security.twofa.TwoFactorAuthService.TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME;
+
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import org.hisp.dhis.user.UserDetails;
+
+public final class TwoFactorSetupSessionAccess {
+  public static final String SESSION_KEY = "2FA_SETUP_REQUIRED";
+
+  private TwoFactorSetupSessionAccess() {}
+
+  public static boolean requiresTwoFactorEnrolment(UserDetails userDetails) {
+    boolean has2FARestriction =
+        userDetails.hasAnyRestrictions(Set.of(TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME));
+    return has2FARestriction && !userDetails.isTwoFactorEnabled();
+  }
+
+  public static void markRequired(HttpServletRequest request) {
+    request.getSession(true).setAttribute(SESSION_KEY, Boolean.TRUE);
+  }
+
+  public static void clear(HttpServletRequest request) {
+    HttpSession session = request.getSession(false);
+    if (session != null) {
+      session.removeAttribute(SESSION_KEY);
+    }
+  }
+
+  public static boolean isRequired(HttpServletRequest request) {
+    HttpSession session = request.getSession(false);
+    return session != null && Boolean.TRUE.equals(session.getAttribute(SESSION_KEY));
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorSetupSessionAccess.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorSetupSessionAccess.java
@@ -32,7 +32,11 @@ import static org.hisp.dhis.security.twofa.TwoFactorAuthService.TWO_FACTOR_AUTH_
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 public final class TwoFactorSetupSessionAccess {
   public static final String SESSION_KEY = "2FA_SETUP_REQUIRED";
@@ -59,5 +63,29 @@ public final class TwoFactorSetupSessionAccess {
   public static boolean isRequired(HttpServletRequest request) {
     HttpSession session = request.getSession(false);
     return session != null && Boolean.TRUE.equals(session.getAttribute(SESSION_KEY));
+  }
+
+  /**
+   * Refreshes the cached {@link UserDetails} in the {@link SecurityContextHolder} from a fresh
+   * {@link User} entity. This is needed after 2FA enrollment changes, since the {@link UserDetails}
+   * principal is immutable and would otherwise hold stale {@code isTwoFactorEnabled} state for the
+   * remainder of the session.
+   */
+  public static void refreshSecurityContext(User freshUser, HttpServletRequest request) {
+    Authentication currentAuth = SecurityContextHolder.getContext().getAuthentication();
+    if (currentAuth == null) {
+      return;
+    }
+    UserDetails freshDetails =
+        UserDetails.createUserDetails(freshUser, true, true, null, null, null, null);
+    UsernamePasswordAuthenticationToken newAuth =
+        new UsernamePasswordAuthenticationToken(
+            freshDetails, currentAuth.getCredentials(), freshDetails.getAuthorities());
+    newAuth.setDetails(currentAuth.getDetails());
+    SecurityContextHolder.getContext().setAuthentication(newAuth);
+    HttpSession session = request.getSession(false);
+    if (session != null) {
+      session.setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
+    }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/TwoFactorSetupRestrictionFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/TwoFactorSetupRestrictionFilter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.hisp.dhis.webapi.controller.security.LoginResponse;
+import org.hisp.dhis.webapi.controller.security.TwoFactorSetupSessionAccess;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class TwoFactorSetupRestrictionFilter extends OncePerRequestFilter {
+  private static final String LOGIN_PAGE_PATH = "/dhis-web-login";
+
+  private final ObjectMapper objectMapper;
+  private final List<RequestMatcher> allowedRequests;
+  private final List<RequestMatcher> blockedRequests;
+
+  public TwoFactorSetupRestrictionFilter(String apiContextPath, ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+    this.blockedRequests =
+        List.of(
+            new AntPathRequestMatcher(apiContextPath + "/**/2fa/enabled", HttpMethod.GET.name()));
+    this.allowedRequests =
+        List.of(
+            new AntPathRequestMatcher(apiContextPath + "/**/auth/login", HttpMethod.POST.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/loginConfig", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/2fa/**"),
+            new AntPathRequestMatcher(apiContextPath + "/**/account/verifyEmail"),
+            new AntPathRequestMatcher(apiContextPath + "/system/info", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/system/info", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/userSettings", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/me", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/me", HttpMethod.PUT.name()),
+            new AntPathRequestMatcher(
+                apiContextPath + "/**/me/authorization", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/me/dashboard", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/systemSettings", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(
+                apiContextPath + "/**/systemSettings/**", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(
+                apiContextPath + "/**/staticContent/logo_banner", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(
+                apiContextPath + "/**/staticContent/logo_front.png", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/schemas", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/attributes", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/apps", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/system/styles", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/locales/ui", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/locales/db", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(
+                apiContextPath + "/**/configuration/twoFactorMethods", HttpMethod.GET.name()),
+            new AntPathRequestMatcher(
+                apiContextPath + "/**/account/sendEmailVerification", HttpMethod.POST.name()),
+            new AntPathRequestMatcher(apiContextPath + "/**/auth/logout"),
+            new AntPathRequestMatcher("/dhis-web-login/**"),
+            new AntPathRequestMatcher("/dhis-web-commons/**"),
+            new AntPathRequestMatcher("/dhis-web-user-profile/**"));
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (HttpMethod.OPTIONS.matches(request.getMethod())
+        || !TwoFactorSetupSessionAccess.isRequired(request)
+        || isAllowed(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    if (isAppNavigation(request)) {
+      response.sendRedirect(request.getContextPath() + LOGIN_PAGE_PATH);
+      return;
+    }
+
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    objectMapper.writeValue(
+        response.getOutputStream(),
+        LoginResponse.builder()
+            .loginStatus(LoginResponse.STATUS.REQUIRES_TWO_FACTOR_ENROLMENT)
+            .build());
+  }
+
+  private boolean isAllowed(HttpServletRequest request) {
+    return blockedRequests.stream().noneMatch(pattern -> pattern.matches(request))
+        && allowedRequests.stream().anyMatch(pattern -> pattern.matches(request));
+  }
+
+  private boolean isAppNavigation(HttpServletRequest request) {
+    String requestURI = request.getRequestURI();
+    String contextPath = request.getContextPath();
+    String path = requestURI.substring(contextPath.length());
+
+    // Don't redirect API requests (they get 403 JSON response)
+    if (path.startsWith("/api/") && !path.startsWith("/api/apps/")) {
+      return false;
+    }
+
+    // Redirect all other non-API requests (web pages, core apps, bundled apps, etc.)
+    return true;
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/TwoFactorSetupRestrictionFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/TwoFactorSetupRestrictionFilter.java
@@ -34,10 +34,13 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.controller.security.LoginResponse;
 import org.hisp.dhis.webapi.controller.security.TwoFactorSetupSessionAccess;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -96,7 +99,7 @@ public class TwoFactorSetupRestrictionFilter extends OncePerRequestFilter {
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     if (HttpMethod.OPTIONS.matches(request.getMethod())
-        || !TwoFactorSetupSessionAccess.isRequired(request)
+        || !isTwoFactorSetupRequired(request)
         || isAllowed(request)) {
       filterChain.doFilter(request, response);
       return;
@@ -115,6 +118,18 @@ public class TwoFactorSetupRestrictionFilter extends OncePerRequestFilter {
         LoginResponse.builder()
             .loginStatus(LoginResponse.STATUS.REQUIRES_TWO_FACTOR_ENROLMENT)
             .build());
+  }
+
+  private boolean isTwoFactorSetupRequired(HttpServletRequest request) {
+    if (TwoFactorSetupSessionAccess.isRequired(request)) {
+      return true;
+    }
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null
+        && authentication.getPrincipal() instanceof UserDetails userDetails) {
+      return TwoFactorSetupSessionAccess.requiresTwoFactorEnrolment(userDetails);
+    }
+    return false;
   }
 
   private boolean isAllowed(HttpServletRequest request) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.security.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -55,6 +56,7 @@ import org.hisp.dhis.webapi.controller.security.AuthenticationController;
 import org.hisp.dhis.webapi.filter.CorsFilter;
 import org.hisp.dhis.webapi.filter.CspFilter;
 import org.hisp.dhis.webapi.filter.CustomAuthenticationFilter;
+import org.hisp.dhis.webapi.filter.TwoFactorSetupRestrictionFilter;
 import org.hisp.dhis.webapi.oprovider.DhisOauthAuthenticationProvider;
 import org.hisp.dhis.webapi.security.ExternalAccessVoter;
 import org.hisp.dhis.webapi.security.FormLoginBasicAuthenticationEntryPoint;
@@ -133,6 +135,10 @@ public class DhisWebApiWebSecurityConfig {
 
   public static void setApiContextPath(String apiContextPath) {
     DhisWebApiWebSecurityConfig.apiContextPath = apiContextPath;
+  }
+
+  public static String getApiContextPath() {
+    return apiContextPath;
   }
 
   @Autowired public DataSource dataSource;
@@ -367,6 +373,8 @@ public class DhisWebApiWebSecurityConfig {
 
     @Autowired private AuthenticationController authenticationController;
 
+    @Autowired private ObjectMapper objectMapper;
+
     @Override
     public void configure(AuthenticationManagerBuilder auth) {
       auth.authenticationProvider(customLdapAuthenticationProvider);
@@ -494,6 +502,7 @@ public class DhisWebApiWebSecurityConfig {
       configureMobileAuthFilter(http);
       configureApiTokenAuthorizationFilter(http);
       configureOAuthTokenFilters(http);
+      configureTwoFactorSetupRestrictionFilter(http);
 
       setHttpHeaders(http);
     }
@@ -598,6 +607,12 @@ public class DhisWebApiWebSecurityConfig {
         http.addFilterAfter(
             getJwtBearerTokenAuthenticationFilter(), BasicAuthenticationFilter.class);
       }
+    }
+
+    private void configureTwoFactorSetupRestrictionFilter(HttpSecurity http) {
+      http.addFilterAfter(
+          new TwoFactorSetupRestrictionFilter(apiContextPath, objectMapper),
+          BasicAuthenticationFilter.class);
     }
 
     /**

--- a/dhis-2/dhis-web-embedded-jetty/pom.xml
+++ b/dhis-2/dhis-web-embedded-jetty/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-web-embedded-jetty</artifactId>

--- a/dhis-2/dhis-web-embedded-jetty/pom.xml
+++ b/dhis-2/dhis-web-embedded-jetty/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-web-embedded-jetty</artifactId>

--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-web-apps</artifactId>

--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-web-apps</artifactId>

--- a/dhis-2/dhis-web/dhis-web-commons-resources/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-web-commons-resources</artifactId>

--- a/dhis-2/dhis-web/dhis-web-commons-resources/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-web-commons-resources</artifactId>

--- a/dhis-2/dhis-web/dhis-web-commons/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-web-commons</artifactId>

--- a/dhis-2/dhis-web/dhis-web-commons/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-web-commons</artifactId>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -27,8 +27,10 @@
  */
 package org.hisp.dhis.security.config;
 
+import static org.hisp.dhis.webapi.security.config.DhisWebApiWebSecurityConfig.getApiContextPath;
 import static org.hisp.dhis.webapi.security.config.DhisWebApiWebSecurityConfig.setHttpHeaders;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +49,7 @@ import org.hisp.dhis.security.vote.ModuleAccessVoter;
 import org.hisp.dhis.webapi.filter.CorsFilter;
 import org.hisp.dhis.webapi.filter.CspFilter;
 import org.hisp.dhis.webapi.filter.CustomAuthenticationFilter;
+import org.hisp.dhis.webapi.filter.TwoFactorSetupRestrictionFilter;
 import org.hisp.dhis.webapi.handler.DefaultAuthenticationSuccessHandler;
 import org.hisp.dhis.webapi.security.ExternalAccessVoter;
 import org.hisp.dhis.webapi.security.Http401LoginUrlAuthenticationEntryPoint;
@@ -127,6 +130,8 @@ public class DhisWebCommonsWebSecurityConfig {
     @Autowired private DefaultAuthenticationEventPublisher authenticationEventPublisher;
 
     @Autowired private ConfigurationService configurationService;
+
+    @Autowired private ObjectMapper objectMapper;
 
     @Override
     public void configure(WebSecurity web) {
@@ -267,6 +272,9 @@ public class DhisWebCommonsWebSecurityConfig {
           .addFilterBefore(CorsFilter.get(), BasicAuthenticationFilter.class)
           .addFilterBefore(
               CustomAuthenticationFilter.get(), UsernamePasswordAuthenticationFilter.class)
+          .addFilterAfter(
+              new TwoFactorSetupRestrictionFilter(getApiContextPath(), objectMapper),
+              BasicAuthenticationFilter.class)
           .sessionManagement()
           .requireExplicitAuthenticationStrategy(true)
           .sessionFixation()

--- a/dhis-2/dhis-web/dhis-web-dataentry/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-dataentry/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-web-dataentry</artifactId>

--- a/dhis-2/dhis-web/dhis-web-dataentry/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-dataentry/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-web-dataentry</artifactId>

--- a/dhis-2/dhis-web/dhis-web-portal/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
 
   <artifactId>dhis-web-portal</artifactId>

--- a/dhis-2/dhis-web/dhis-web-portal/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-web</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
 
   <artifactId>dhis-web-portal</artifactId>

--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-2</version>
+    <version>2.41.6.1-eyeseetea-fork-3</version>
   </parent>
   <artifactId>dhis-web</artifactId>
   <packaging>pom</packaging>

--- a/dhis-2/dhis-web/pom.xml
+++ b/dhis-2/dhis-web/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis</artifactId>
-    <version>2.41.6.1-eyeseetea-fork-1</version>
+    <version>2.41.6.1-eyeseetea-fork-2</version>
   </parent>
   <artifactId>dhis-web</artifactId>
   <packaging>pom</packaging>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.hisp.dhis</groupId>
   <artifactId>dhis</artifactId>
-  <version>2.41.6.1-eyeseetea-fork-2</version>
+  <version>2.41.6.1-eyeseetea-fork-3</version>
   <packaging>pom</packaging>
   <name>DHIS2</name>
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.hisp.dhis</groupId>
   <artifactId>dhis</artifactId>
-  <version>2.41.6.1-eyeseetea-fork-1</version>
+  <version>2.41.6.1-eyeseetea-fork-2</version>
   <packaging>pom</packaging>
   <name>DHIS2</name>
 


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869c45wmu

**Implementation details:**

**2.41.6.1-eyeseetea-fork-2**

- allow 2FA restricted users to login while restricting access
- mark 2FA restricted users session with a custom attribute
- custom filter allows only necessary endpoints for restricted users to setup 2FA, 
- custom filter redirects restricted users to login-app when trying to navigate to any other app that is not login-app or user-profile-app
- clear restriction upon 2FA enrollment

**2.41.6.1-eyeseetea-fork-3**

- disallow restricted users from making api requests
  - thought this was already handled by the restriction and not in scope for this PR, but was not the case
  - after adding this change, also had to refresh the user in context after enrolling 2FA, to avoid getting incorrect unauthorized errors
  - restricted users still able to make requests to allowed endpoints necessary to complete 2FA setup
