### PR TITLE
fix: handle identifiable in metadata filters in v42 [DHIS2-20193]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryParser.java
@@ -155,7 +155,7 @@ public class DefaultQueryParser implements QueryParser {
   @SuppressWarnings("rawtypes")
   private Collection parseValues(Property property, Class<?> valueType, Object arg) {
     Collection<?> values =
-        property.isCollection()
+        property != null && property.isCollection()
             ? parseValue(Collection.class, property.getItemKlass(), arg)
             : parseValue(Collection.class, valueType, arg);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
@@ -44,9 +44,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.jpa.QueryHints;
@@ -55,6 +57,7 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.hibernate.InternalHibernateGenericStore;
 import org.hisp.dhis.query.operators.Operator;
+import org.hisp.dhis.query.planner.PropertyPath;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.user.UserDetails;
@@ -250,19 +253,26 @@ public class JpaCriteriaQueryEngine implements QueryEngine {
       CriteriaBuilder builder, Root<Y> root, Filter filter, Query<?> query) {
     Predicate or = builder.disjunction();
     Operator<?> op = filter.getOperator();
-    Function<String, Predicate> getPredicate =
-        path ->
-            op.getPredicate(
-                builder, root, schemaService.getPropertyPath(query.getObjectType(), path));
-    Consumer<Predicate> add =
-        p -> {
-          if (p != null) or.getExpressions().add(p);
-        };
-    add.accept(getPredicate.apply("id"));
-    add.accept(getPredicate.apply("code"));
-    add.accept(getPredicate.apply("name"));
-    if (query.isShortNamePersisted()) add.accept(getPredicate.apply("shortName"));
+
+    Stream.of("id", "code", "name", "shortName")
+        .map(path -> getDbPropertyPath(query.getObjectType(), path))
+        .filter(Objects::nonNull)
+        .map(path -> op.getPredicate(builder, root, path))
+        .filter(Objects::nonNull)
+        .forEach(or.getExpressions()::add);
+
     return or;
+  }
+
+  private PropertyPath getDbPropertyPath(Class<?> objectType, String path) {
+    try {
+      PropertyPath propertyPath = schemaService.getPropertyPath(objectType, path);
+      return propertyPath != null && propertyPath.isPersisted() && !propertyPath.haveAlias()
+          ? propertyPath
+          : null;
+    } catch (RuntimeException ignored) {
+      return null;
+    }
   }
 
   private <Y> Predicate buildQueryFilter(CriteriaBuilder builder, Root<Y> root, Filter filter) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -202,7 +202,8 @@ class MetadataImportExportControllerTest extends H2ControllerIntegrationTestBase
 
   @Test
   void testGetWithIdentifiableFilterAndFieldsId() {
-    JsonMixed response = GET("/metadata?filter=identifiable:eq:default&fields=id").content(HttpStatus.OK);
+    JsonMixed response =
+        GET("/metadata?filter=identifiable:eq:default&fields=id").content(HttpStatus.OK);
     assertNotNull(response);
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -201,6 +201,20 @@ class MetadataImportExportControllerTest extends H2ControllerIntegrationTestBase
   }
 
   @Test
+  void testGetWithIdentifiableFilterAndFieldsId() {
+    JsonMixed response = GET("/metadata?filter=identifiable:eq:default&fields=id").content(HttpStatus.OK);
+    assertNotNull(response);
+  }
+
+  @Test
+  void testGetWithIdentifiableInFilterForSpecificMetadataClass() {
+    JsonMixed response =
+        GET("/metadata?attributes:fields=id,code,name&attributes:filter=identifiable:in:[IRID]")
+            .content(HttpStatus.OK);
+    assertNotNull(response);
+  }
+
+  @Test
   void testPostValidGeoJsonAttribute() throws IOException {
     POST(
             "/metadata",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramRuleActionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramRuleActionControllerTest.java
@@ -193,4 +193,9 @@ class ProgramRuleActionControllerTest extends H2ControllerIntegrationTestBase {
     actions.forEach(
         action -> assertEquals(program.getUid(), action.getProgramRule().getProgram().getUid()));
   }
+
+  @Test
+  void testGetProgramRuleActionsWithIdentifiableFilter() {
+    assertNotNull(GET("/programRuleActions?filter=identifiable:eq:default").content(HttpStatus.OK));
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsCommandControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsCommandControllerTest.java
@@ -64,4 +64,10 @@ class SmsCommandControllerTest extends H2ControllerIntegrationTestBase {
     JsonMixed content = GET("/smsCommands").content(HttpStatus.OK);
     assertNotNull(content);
   }
+
+  @Test
+  void testGetSmsCommandsWithIdentifiableFilter() {
+    JsonMixed content = GET("/smsCommands?filter=identifiable:eq:default").content(HttpStatus.OK);
+    assertNotNull(content);
+  }
 }


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869d78d3e - not directly related, but a blocker in several apps like metadata-sync while migrating to v42

## Summary
Fix `identifiable` filtering for metadata exports without regressing the query planner back to full in-memory filtering.

This keeps `identifiable` on the DB path where possible, while safely skipping unavailable candidate properties per schema. It also fixes the `identifiable:in` parsing edge case for metadata section filters.

This fixes the following: 
- GET `/metadata?filter=identifiable:eq:default&fields=id` -> Error 400, with `"Unable to locate Attribute  with the the given name [code] on this ManagedType [org.hisp.dhis.sms.command.SMSCommand]"`, or `"Unable to locate Attribute  with the the given name [name] on this ManagedType [org.hisp.dhis.programrule.ProgramRuleAction]"` depending on the instance - more entities could exist with the same issue. 
- GET `/metadata?attributes:fields=id,code,name&attributes:filter=identifiable:in:[IRID]` -> Error 500 with `"Cannot invoke \"org.hisp.dhis.schema.Property.isCollection()\" because \"property\" is null"`

## Changes
- Make `JpaCriteriaQueryEngine` only add identifiable predicates for persisted, valid schema properties.
- Make `DefaultQueryParser` tolerate virtual filters where `property == null` for `in` / `!in`.
- Add regression coverage for:
  - `/metadata?filter=identifiable:eq:default&fields=id`
  - `/metadata?attributes:fields=id,code,name&attributes:filter=identifiable:in:[IRID]`
  - Cases for `programRuleActions` and `smsCommands`
  - These tests are not in-depth or precise but demonstrates the issue

## Issue
- [DHIS2-20193](https://dhis2.atlassian.net/browse/DHIS2-20193)
- Related: Upstream PRs 20008 and 20097 which introduced significant performance improvements.